### PR TITLE
feat: add a `Link` type that uses `LineElement.Link`

### DIFF
--- a/src/Helpers.fs
+++ b/src/Helpers.fs
@@ -7,7 +7,11 @@ let text s = LineElement.Text s
 let img src title alt =
     LineElement.Image(src, title, alt)
 let url href title description =
-    LineElement.Link(href, title, description)
+    LineElement.Link {
+        Href = href
+        Title = title
+        Description = description
+    }
 
 let h level title body =
     Statement.Header {

--- a/tests/SyntaxTree.Tests.fs
+++ b/tests/SyntaxTree.Tests.fs
@@ -69,46 +69,46 @@ let ``LineElement.Parser.pimage`` =
     ]
 
 [<Tests>]
-let ``LineElement.Parser.plink`` =
-    let parser = LineElement.Parser.plink Line.Parser.parse
-    testList "LineElement.Parser.plink" [
+let ``Link.Parser.parser`` =
+    let parser = Link.Parser.parser Line.Parser.parse
+    testList "Link.Parser.parser" [
         testCase "[]()" <| fun () ->
             Assert.Equal(
                 "",
                 runResult parser "[]()",
-                Ok {| Description = []; Href = ""; Title = None; |}
+                Ok { Description = []; Href = ""; Title = ""; }
             )
         testCase "[](https://example.com/image.png)" <| fun () ->
             Assert.Equal(
                 "",
                 runResult parser "[](https://example.com/image.png)",
-                Ok {|
+                Ok {
                     Description = []
                     Href = "https://example.com/image.png"
-                    Title = None
-                |}
+                    Title = ""
+                }
             )
         testCase "[](https://example.com/image.png \"title\")" <| fun () ->
             Assert.Equal(
                 "",
                 runResult parser "[](https://example.com/image.png \"title\")",
-                Ok {|
+                Ok {
                     Description = []
                     Href = "https://example.com/image.png"
-                    Title = Some "title"
-                |}
+                    Title = "title"
+                }
             )
         testCase "[image alt](https://example.com/image.png \"title\")" <| fun () ->
             Assert.Equal(
                 "",
                 runResult parser "[image alt](https://example.com/image.png \"title\")",
-                Ok {|
+                Ok {
                     Description = [
                         LineElement.Text "image alt"
                     ]
                     Href = "https://example.com/image.png"
-                    Title = Some "title"
-                |}
+                    Title = "title"
+                }
             )
     ]
 


### PR DESCRIPTION
Closes: #25